### PR TITLE
Fix interface filtering and add more patterns

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -34,12 +34,13 @@ function getBytes() {
       break;
     }
     if (
-      !column[0].match("lo") &&
+      !column[0].match(/^lo$/) &&
       !column[0].match(/^br[0-9]+/) &&
       !column[0].match(/^tun[0-9]+/) &&
       !column[0].match(/^tap[0-9]+/) &&
       !column[0].match(/^vnet[0-9]+/) &&
-      !column[0].match(/^virbr[0-9]+/)
+      !column[0].match(/^virbr[0-9]+/) &&
+      !column[0].match(/^docker[0-9]+/) 
     ) {
       let download = parseInt(column[1]);
       let upload = parseInt(column[9]);


### PR DESCRIPTION
Exactly match the interface "lo".
Filter docker interfaces.

Fixes #15 introduced by c4fec82ada236e65d4aed6bd27cfd99edd4a31bb