### PR TITLE
Ignore docker related interfaces to prevent double counting

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -43,7 +43,8 @@ export default class InternetSpeedMeter extends Extension {
         !column[0].match(/^tun[0-9]+/) &&
         !column[0].match(/^tap[0-9]+/) &&
         !column[0].match(/^vnet[0-9]+/) &&
-        !column[0].match(/^virbr[0-9]+/)
+        !column[0].match(/^virbr[0-9]+/) &&
+        !column[0].match(/^(veth|br-|docker0)[a-zA-Z0-9]+/)
       ) {
         let download = parseInt(column[1]);
         let upload = parseInt(column[9]);


### PR DESCRIPTION
Docker related interfaces lead to double counting. Eg: If a container used 10MB/s, the bytes from the internet adapter and the bytes from the container adapter is both counted leading to double the actual rate displayed.